### PR TITLE
Allow Quantity input and convert automatically for wavelength

### DIFF
--- a/astrogrism/HST/transform_models.py
+++ b/astrogrism/HST/transform_models.py
@@ -56,7 +56,7 @@ class AstrogrismForwardGrismDispersion(Model):
         if name is None:
             name = 'astrogrism_forward_grism_dispersion'
         super(AstrogrismForwardGrismDispersion, self).__init__(name=name,
-                                                           meta=meta)
+                                                               meta=meta)
         # starts with the backwards pixel and calculates the forward pixel
         self.inputs = ("x", "y", "x0", "y0", "order")
         self.outputs = ("x", "y", "wavelength", "order")
@@ -124,7 +124,7 @@ class AstrogrismForwardGrismDispersion(Model):
             model = Mapping((2, 3, 0, 1, 0, 2, 4)) | (Const1D(x0) & Const1D(y0) &
                                                       wavelength & Const1D(order))
 
-        x_out, y_out, wavelength, order =  model(x, y, x0, y0, order)
+        x_out, y_out, wavelength, order = model(x, y, x0, y0, order)
         return x_out, y_out, wavelength*u.Unit(self.l_unit), order
 
 
@@ -179,7 +179,7 @@ class AstrogrismBackwardGrismDispersion(Model):
         if name is None:
             name = 'astrogrism_backward_grism_dispersion'
         super(AstrogrismBackwardGrismDispersion, self).__init__(name=name,
-                                                            meta=meta)
+                                                                meta=meta)
         self.inputs = ("x", "y", "wavelength", "order")
         self.outputs = ("x", "y", "x0", "y0", "order")
 

--- a/astrogrism/HST/transform_models.py
+++ b/astrogrism/HST/transform_models.py
@@ -124,7 +124,8 @@ class AstrogrismForwardGrismDispersion(Model):
             model = Mapping((2, 3, 0, 1, 0, 2, 4)) | (Const1D(x0) & Const1D(y0) &
                                                       wavelength & Const1D(order))
 
-        return model(x, y, x0, y0, order)
+        x_out, y_out, wavelength, order =  model(x, y, x0, y0, order)
+        return x_out, y_out, wavelength*u.Unit(self.l_unit), order
 
 
 class AstrogrismBackwardGrismDispersion(Model):

--- a/astrogrism/HST/transform_models.py
+++ b/astrogrism/HST/transform_models.py
@@ -218,7 +218,7 @@ class AstrogrismBackwardGrismDispersion(Model):
 
         # Check if wavelength is in unit expected (if Quantity)
         if isinstance(wavelength, u.Quantity):
-            wavelength = wavelength.to(self.l_unit)
+            wavelength = wavelength.to(self.l_unit).value
         else:
             warnings.warn(f"Assuming input wavelength is in {self.l_unit}. To "
                           "specify wavelength unit, input an astropy Quantity.")

--- a/astrogrism/grism_observation.py
+++ b/astrogrism/grism_observation.py
@@ -65,7 +65,6 @@ class GrismObs():
             self.filter = filter
 
         # Build GWCS geometric transform pipeline
-        print(self.instrument)
         if self.filter in ("G280", "G800L"):
             # Need to build transforms for both channels of WFC3 UVIS and ACS WFC
             self.geometric_transforms = {}

--- a/astrogrism/grism_observation.py
+++ b/astrogrism/grism_observation.py
@@ -103,7 +103,7 @@ class GrismObs():
             elif self.filter == "G280":
                 instrument = f"{self.instrument}_UVIS"
                 filter = f"{self.filter}_CCD{channel}"
-                l_unit = "angstrom"
+                l_unit = "Angstrom"
             elif self.filter == "G800L":
                 instrument = "ACS_WFC"
                 filter = f"{self.filter}_CCD{channel}"
@@ -135,7 +135,8 @@ class GrismObs():
         det2det = AstrogrismForwardGrismDispersion(orders,
                                                    lmodels=displ,
                                                    xmodels=invdispx,
-                                                   ymodels=dispy)
+                                                   ymodels=dispy,
+                                                   l_unit=l_unit)
         # TODO: Decide where to raise a warning if we can't do the backward
         # grism transformation (UVIS, at least for now).
         if invdispl is not None:

--- a/astrogrism/grism_observation.py
+++ b/astrogrism/grism_observation.py
@@ -111,7 +111,6 @@ class GrismObs():
             instrument = self.instrument
             filter = self.filter
 
-
         sip_file = config_dir / "{}_distortion.fits".format(instrument)
         spec_wcs_file = config_dir / "{}_{}_specwcs.asdf".format(
                                                        self.instrument,
@@ -134,24 +133,24 @@ class GrismObs():
                                axes_order=(0, 1),
                                unit=(u.pix, u.pix))
         det2det = AstrogrismForwardGrismDispersion(orders,
-                                               lmodels=displ,
-                                               xmodels=invdispx,
-                                               ymodels=dispy)
+                                                   lmodels=displ,
+                                                   xmodels=invdispx,
+                                                   ymodels=dispy)
         # TODO: Decide where to raise a warning if we can't do the backward
         # grism transformation (UVIS, at least for now).
         if invdispl is not None:
             det2det.inverse = AstrogrismBackwardGrismDispersion(orders,
-                                                            lmodels=invdispl,
-                                                            xmodels=dispx,
-                                                            ymodels=dispy,
-                                                            l_unit=l_unit)
+                                                                lmodels=invdispl,
+                                                                xmodels=dispx,
+                                                                ymodels=dispy,
+                                                                l_unit=l_unit)
         else:
             det2det.inverse = AstrogrismBackwardGrismDispersion(orders,
-                                                            lmodels=displ,
-                                                            xmodels=dispx,
-                                                            ymodels=dispy,
-                                                            interpolate_t=True,
-                                                            l_unit=l_unit)
+                                                                lmodels=displ,
+                                                                xmodels=dispx,
+                                                                ymodels=dispy,
+                                                                interpolate_t=True,
+                                                                l_unit=l_unit)
 
         grism_pipeline = [(gdetector, det2det)]
 

--- a/astrogrism/tests/test_acs_g800l.py
+++ b/astrogrism/tests/test_acs_g800l.py
@@ -2,6 +2,8 @@ from astrogrism import GrismObs
 
 import pathlib
 import numpy as np
+from astropy.tests.helper import assert_quantity_allclose
+import astropy.units as u
 
 # TODO: Switch to importlib
 test_dir = pathlib.Path(__file__).parent.absolute()
@@ -29,7 +31,7 @@ def test_acs_g800l_roundtrip():
     np.testing.assert_allclose(d2g2(1024.0, 2048.0, 0.7, 1.0), d2g2_expected, atol=5e-2)
 
     # Now test transforming all the way end to end
-    world_ref = (264.1018298204877, -32.90801703429679, 0.7, 1.0)
+    world_ref = (264.1018298204877, -32.90801703429679, 0.7*u.Unit("micron"), 1.0)
 
     g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_detector", "world")
     w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
@@ -44,5 +46,10 @@ def test_acs_g800l_roundtrip():
     np.testing.assert_allclose(w2g2(*world_ref), w2g2_expected, atol=5e-5)
 
     # Use rtol here because the wavelength doesn't round trip perfectly
-    np.testing.assert_allclose(g2w1(*w2g1_expected), world_ref, rtol=0.005)
-    np.testing.assert_allclose(g2w2(*w2g2_expected), world_ref, rtol=0.005)
+    g2w1_res = g2w1(*w2g1_expected)
+    g2w2_res = g2w2(*w2g2_expected)
+
+    [assert_quantity_allclose(g2w1_res[i], world_ref[i], rtol=0.005) for i in
+     range(len(world_ref))]
+    [assert_quantity_allclose(g2w2_res[i], world_ref[i], rtol=0.005) for i in
+     range(len(world_ref))]

--- a/astrogrism/tests/test_wfc3_g280.py
+++ b/astrogrism/tests/test_wfc3_g280.py
@@ -2,6 +2,8 @@ from astrogrism import GrismObs
 
 import pathlib
 import numpy as np
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 # TODO: Switch to importlib
 test_dir = pathlib.Path(__file__).parent.absolute()
@@ -29,7 +31,7 @@ def test_wfc3_g280_roundtrip():
     np.testing.assert_allclose(d2g2(1000.0, 1500.0, 5000, 1.0), d2g2_expected, atol=5e-2)
 
     # Now test transforming all the way end to end
-    world_ref = (206.4318333333, 26.41859444444, 4000, 1.0)
+    world_ref = (206.4318333333, 26.41859444444, 4000*u.AA, 1.0)
 
     g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_detector", "world")
     w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
@@ -46,5 +48,9 @@ def test_wfc3_g280_roundtrip():
     np.testing.assert_allclose(w2g2(*world_ref), w2g2_expected, atol=5e-5)
 
     # Use rtol here because the wavelength doesn't round trip perfectly
-    np.testing.assert_allclose(g2w1(*w2g1_expected), world_ref, rtol=0.005)
-    np.testing.assert_allclose(g2w2(*w2g2_expected), world_ref, rtol=0.005)
+    g2w1_res = g2w1(*w2g1_expected)
+    g2w2_res = g2w2(*w2g2_expected)
+    [assert_quantity_allclose(g2w1_res[i], world_ref[i], rtol=0.005) for i in
+     range(len(world_ref))]
+    [assert_quantity_allclose(g2w2_res[i], world_ref[i], rtol=0.005) for i in
+     range(len(world_ref))]

--- a/docs/transforms.rst
+++ b/docs/transforms.rst
@@ -12,9 +12,10 @@ each frame are listed below - note that the input needed to go from e.g. the
 world to the direct detector frame is the same as the output of the transform
 in the other direction, e.g. from the direct detector to the world frame.
 
-Future work will allow astropy ``Quantity`` input and convert units automatically
-if needed, but currently there are specific requirements for the units of the 
-inputs. 
+Astropy ``Quantity`` input is currently accepted for wavelength, which will 
+be converted automatically internally to the necessary units in that case. 
+Currently, sky coordinates (right ascension and declination) must be input 
+as decimal degrees. 
 
 
 World
@@ -24,7 +25,10 @@ Input/Output: ``(right ascension, declination, wavelength, order)``
 
 The ``right ascension`` and ``declination`` are specified in degrees. The 
 ``wavelength`` units depend on instrument: Micron for ACS and WFC3 IR, 
-Angstrom for WFC3 UVIS. The dispersion ``order`` is a unitless integer. 
+Angstrom for WFC3 UVIS. If the wavelength is input as an astropy ``Quantity``, 
+it will be automatically converted to the correct units, otherwise (if a float
+is input) it must be in the correct units. The dispersion ``order`` is a 
+unitless integer. 
 
 Direct Detector
 ---------------


### PR DESCRIPTION
This allows the user to input the wavelength as an astropy Quantity with units, so they don't have to remember which units to use for the different instruments. I need one more commit to add the units to the wavelength output. This seemed more important than allowing any type of sky coordinate input (which I'll work on after this).

I also took the opportunity to further generalize some class names.