### PR TITLE
Fix ACS specwcs file generation

### DIFF
--- a/astrogrism/config/HST/reference_file_generators/_generate_specwcs.py
+++ b/astrogrism/config/HST/reference_file_generators/_generate_specwcs.py
@@ -245,7 +245,7 @@ def create_grism_specwcs(conffile="",
         wave_units = u.micron
     elif pupil == "G800L":
         channel = "WFC"
-        wave_units = u.micron
+        wave_units = u.AA
     else:
         raise NotImplementedError("G102, G141, G280, G800L Grisms supported, not " + str(pupil))
 


### PR DESCRIPTION
I realized during array input testing that the ACS `l_coeff` conversion was hard coded wrong. ACS expects micron inputs in the transforms, but the coefficients in the GRISMCONF files are actually in Angstrom, so they don't need conversion here.