### PR TITLE
Fix SIP calculations for multi-channel files

### DIFF
--- a/astrogrism/grism_observation.py
+++ b/astrogrism/grism_observation.py
@@ -159,11 +159,21 @@ class GrismObs():
 
         # Get the correct hdu from the SIP file
         if channel is not None:
-            for hdu in sip_hdus:
+            for i in range(len(sip_hdus)):
+                hdu = sip_hdus[i]
                 if "CCDCHIP" in hdu.header and hdu.header["CCDCHIP"] == channel:
-                    sip_hdu = hdu
+                    sip_hdu_index = i
+                    break
+            for i in range(len(self.grism_image)):
+                hdu = self.grism_image[i]
+                if "CCDCHIP" in hdu.header and hdu.header["CCDCHIP"] == channel:
+                    hdu_index = i
+                    break
         else:
-            sip_hdu = sip_hdus[1]
+            hdu_index = 1
+            sip_hdu_index = 1
+
+        sip_hdu = sip_hdus[sip_hdu_index]
 
         acoef = dict(sip_hdu.header['A_*'])
         a_order = acoef.pop('A_ORDER')
@@ -182,15 +192,16 @@ class GrismObs():
         except ValueError:
             raise
 
-        crpix = [self.grism_image[1].header['CRPIX1'], self.grism_image[1].header['CRPIX2']]
+        crpix = [self.grism_image[hdu_index].header['CRPIX1'],
+                 self.grism_image[hdu_index].header['CRPIX2']]
 
-        crval = [self.grism_image[1].header['CRVAL1'],
-                 self.grism_image[1].header['CRVAL2']]
+        crval = [self.grism_image[hdu_index].header['CRVAL1'],
+                 self.grism_image[hdu_index].header['CRVAL2']]
 
-        cdmat = np.array([[self.grism_image[1].header['CD1_1'],
-                           self.grism_image[1].header['CD1_2']],
-                          [self.grism_image[1].header['CD2_1'],
-                           self.grism_image[1].header['CD2_2']]])
+        cdmat = np.array([[self.grism_image[hdu_index].header['CD1_1'],
+                           self.grism_image[hdu_index].header['CD1_2']],
+                          [self.grism_image[hdu_index].header['CD2_1'],
+                           self.grism_image[hdu_index].header['CD2_2']]])
 
         a_polycoef = {}
         for key in acoef:

--- a/astrogrism/tests/test_acs_g800l.py
+++ b/astrogrism/tests/test_acs_g800l.py
@@ -19,7 +19,7 @@ def test_acs_g800l_roundtrip():
 
     assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
                                                                        'detector', 'world']
-    assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
+    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_detector',
                                                                        'detector', 'world']
 
     # Check that detector -> grism is working before checking full transform
@@ -55,4 +55,26 @@ def test_acs_g800l_roundtrip():
     [assert_quantity_allclose(g2w1_res[i], world_ref1[i], rtol=0.005) for i in
      range(len(world_ref1))]
     [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
+     range(len(world_ref2))]
+
+    # Test world <-> detector transforms
+    w2d1_expected = (2047, 1023, 0.7*u.Unit("micron"), 1.0)
+    w2d2_expected = (2047, 1023, 0.7*u.Unit("micron"), 1.0)
+
+    d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "world")
+    w2d1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "detector")
+
+    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "world")
+    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "detector")
+
+    [assert_quantity_allclose(w2d1(*world_ref1)[i], w2d1_expected[i], rtol=5e-5) for
+     i in range(len(world_ref1))]
+    [assert_quantity_allclose(w2d2(*world_ref2)[i], w2d2_expected[i], rtol=5e-5) for
+     i in range(len(world_ref2))]
+
+    d2w1_res = d2w1(*w2d1_expected)
+    d2w2_res = d2w2(*w2d2_expected)
+    [assert_quantity_allclose(d2w1_res[i], world_ref1[i], rtol=0.005) for i in
+     range(len(world_ref1))]
+    [assert_quantity_allclose(d2w2_res[i], world_ref2[i], rtol=0.005) for i in
      range(len(world_ref2))]

--- a/astrogrism/tests/test_acs_g800l.py
+++ b/astrogrism/tests/test_acs_g800l.py
@@ -19,6 +19,8 @@ def test_acs_g800l_roundtrip():
 
     assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
                                                                        'detector', 'world']
+    assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
+                                                                       'detector', 'world']
 
     # Check that detector -> grism is working before checking full transform
     d2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "grism_detector")
@@ -31,7 +33,8 @@ def test_acs_g800l_roundtrip():
     np.testing.assert_allclose(d2g2(1024.0, 2048.0, 0.7, 1.0), d2g2_expected, atol=5e-2)
 
     # Now test transforming all the way end to end
-    world_ref = (264.1018298204877, -32.90801703429679, 0.7*u.Unit("micron"), 1.0)
+    world_ref1 = (264.0677510637033, -32.91199329438908, 0.7*u.Unit("micron"), 1.0)
+    world_ref2 = (264.1018298204877, -32.90801703429679, 0.7*u.Unit("micron"), 1.0)
 
     g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_detector", "world")
     w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
@@ -42,14 +45,14 @@ def test_acs_g800l_roundtrip():
     w2g1_expected = (2103.325418, 1020.241261, 2047.007260, 1022.979833, 1.0)
     w2g2_expected = (2099.471492, 1020.803474, 2047.001747, 1023.005213, 1.0)
 
-    np.testing.assert_allclose(w2g1(*world_ref), w2g1_expected, atol=5e-5)
-    np.testing.assert_allclose(w2g2(*world_ref), w2g2_expected, atol=5e-5)
+    np.testing.assert_allclose(w2g1(*world_ref1), w2g1_expected, atol=5e-5)
+    np.testing.assert_allclose(w2g2(*world_ref2), w2g2_expected, atol=5e-5)
 
     # Use rtol here because the wavelength doesn't round trip perfectly
     g2w1_res = g2w1(*w2g1_expected)
     g2w2_res = g2w2(*w2g2_expected)
 
-    [assert_quantity_allclose(g2w1_res[i], world_ref[i], rtol=0.005) for i in
-     range(len(world_ref))]
-    [assert_quantity_allclose(g2w2_res[i], world_ref[i], rtol=0.005) for i in
-     range(len(world_ref))]
+    [assert_quantity_allclose(g2w1_res[i], world_ref1[i], rtol=0.005) for i in
+     range(len(world_ref1))]
+    [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
+     range(len(world_ref2))]

--- a/astrogrism/tests/test_wfc3_g280.py
+++ b/astrogrism/tests/test_wfc3_g280.py
@@ -19,6 +19,8 @@ def test_wfc3_g280_roundtrip():
 
     assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
                                                                        'detector', 'world']
+    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_detector',
+                                                                       'detector', 'world']
 
     # Check that detector -> grism is working before checking full transform
     d2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "grism_detector")
@@ -31,7 +33,8 @@ def test_wfc3_g280_roundtrip():
     np.testing.assert_allclose(d2g2(1000.0, 1500.0, 5000, 1.0), d2g2_expected, atol=5e-2)
 
     # Now test transforming all the way end to end
-    world_ref = (206.4318333333, 26.41859444444, 4000*u.AA, 1.0)
+    world_ref1 = (206.45684221694, 26.41827449813, 4000*u.AA, 1.0)
+    world_ref2 = (206.4312669986, 26.41859812035, 4000*u.AA, 1.0)
 
     g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_detector", "world")
     w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
@@ -39,18 +42,18 @@ def test_wfc3_g280_roundtrip():
     g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_detector", "world")
     w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_detector")
 
-    w2g1_expected = (1869.7387435684468, 1245.8356517642842, 2047.2667314355476,
-                     1070.8144590508862, 1.0)
-    w2g2_expected = (1873.0879758597869, 1237.8689879427377, 2047.2665683303317,
-                     1070.814770017469, 1.0)
+    w2g1_expected = (1869.5620631381307, 1199.8189959488238, 2046.9999576026378,
+                     1025.000003223617, 1.0)
+    w2g2_expected = (1872.897871807071, 1191.880590457291, 2047.000039365022,
+                     1024.9999995682701, 1.0)
 
-    np.testing.assert_allclose(w2g1(*world_ref), w2g1_expected, atol=5e-5)
-    np.testing.assert_allclose(w2g2(*world_ref), w2g2_expected, atol=5e-5)
+    np.testing.assert_allclose(w2g1(*world_ref1), w2g1_expected, atol=5e-5)
+    np.testing.assert_allclose(w2g2(*world_ref2), w2g2_expected, atol=5e-5)
 
     # Use rtol here because the wavelength doesn't round trip perfectly
     g2w1_res = g2w1(*w2g1_expected)
     g2w2_res = g2w2(*w2g2_expected)
-    [assert_quantity_allclose(g2w1_res[i], world_ref[i], rtol=0.005) for i in
-     range(len(world_ref))]
-    [assert_quantity_allclose(g2w2_res[i], world_ref[i], rtol=0.005) for i in
-     range(len(world_ref))]
+    [assert_quantity_allclose(g2w1_res[i], world_ref1[i], rtol=0.005) for i in
+     range(len(world_ref1))]
+    [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
+     range(len(world_ref2))]

--- a/astrogrism/tests/test_wfc3_g280.py
+++ b/astrogrism/tests/test_wfc3_g280.py
@@ -57,3 +57,23 @@ def test_wfc3_g280_roundtrip():
      range(len(world_ref1))]
     [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
      range(len(world_ref2))]
+
+    w2d_expected = (2047, 1025, 4000*u.AA, 1.0)
+
+    d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "world")
+    w2d1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "detector")
+
+    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "world")
+    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "detector")
+
+    [assert_quantity_allclose(w2d1(*world_ref1)[i], w2d_expected[i], rtol=5e-5) for
+            i in range(len(world_ref1))]
+    [assert_quantity_allclose(w2d2(*world_ref2)[i], w2d_expected[i], rtol=5e-5) for
+            i in range(len(world_ref2))]
+
+    d2w1_res = d2w1(*w2d_expected)
+    d2w2_res = d2w2(*w2d_expected)
+    [assert_quantity_allclose(d2w1_res[i], world_ref1[i], rtol=0.005) for i in
+     range(len(world_ref1))]
+    [assert_quantity_allclose(d2w2_res[i], world_ref2[i], rtol=0.005) for i in
+     range(len(world_ref2))]

--- a/astrogrism/tests/test_wfc3_g280.py
+++ b/astrogrism/tests/test_wfc3_g280.py
@@ -58,6 +58,7 @@ def test_wfc3_g280_roundtrip():
     [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
      range(len(world_ref2))]
 
+    # Test world <-> detector transforms
     w2d_expected = (2047, 1025, 4000*u.AA, 1.0)
 
     d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "world")
@@ -67,9 +68,9 @@ def test_wfc3_g280_roundtrip():
     w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "detector")
 
     [assert_quantity_allclose(w2d1(*world_ref1)[i], w2d_expected[i], rtol=5e-5) for
-            i in range(len(world_ref1))]
+     i in range(len(world_ref1))]
     [assert_quantity_allclose(w2d2(*world_ref2)[i], w2d_expected[i], rtol=5e-5) for
-            i in range(len(world_ref2))]
+     i in range(len(world_ref2))]
 
     d2w1_res = d2w1(*w2d_expected)
     d2w2_res = d2w2(*w2d_expected)


### PR DESCRIPTION
This fixes a bug where UVIS CCD1 was erroneously using some of the header information for CCD2 in the world<->detector tranforms. I should add a test for this case, but don't have time right this moment. Please take a look in the meantime!