### PR TITLE
Rename direct and grism reference frames for clarity

### DIFF
--- a/astrogrism/grism_observation.py
+++ b/astrogrism/grism_observation.py
@@ -157,7 +157,7 @@ class GrismObs():
             x_offset = 0
             y_offset = 0
 
-        # Build the grism_detector <-> detector transforms
+        # Build the grism_frame <-> direct_frame transforms
         with asdf.open(str(spec_wcs_file)) as f:
             specwcs = f.tree
         displ = specwcs['displ']
@@ -170,7 +170,7 @@ class GrismObs():
         invdispx = specwcs['invdispx']
         orders = specwcs['order']
 
-        gdetector = cf.Frame2D(name='grism_detector',
+        gdetector = cf.Frame2D(name='grism_frame',
                                axes_order=(0, 1),
                                unit=(u.pix, u.pix))
         det2det = AstrogrismForwardGrismDispersion(orders,
@@ -297,7 +297,7 @@ class GrismObs():
 
         imagepipe = []
 
-        det_frame = cf.Frame2D(name="detector")
+        det_frame = cf.Frame2D(name="direct_frame")
         imagepipe.append((det_frame, full_distortion_model))
 
         world_frame = cf.CelestialFrame(name="world", unit=(u.Unit("deg"), u.Unit("deg")),

--- a/astrogrism/tests/test_acs_g800l.py
+++ b/astrogrism/tests/test_acs_g800l.py
@@ -12,19 +12,19 @@ test_dir = pathlib.Path(__file__).parent.absolute()
 def test_acs_g800l_roundtrip():
     """
     Tests Astrogrism transforms round tripping as expected between grism
-    detector, direct detector and world frames.
+    frame, direct frame and world frames.
     """
     test_file = pathlib.Path(test_dir, "data", "acs_test_file.fits")
     grism_obs = GrismObs(str(test_file))
 
-    assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
-                                                                       'detector', 'world']
-    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_detector',
-                                                                       'detector', 'world']
+    assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_frame',
+                                                                       'direct_frame', 'world']
+    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_frame',
+                                                                       'direct_frame', 'world']
 
-    # Check that detector -> grism is working before checking full transform
-    d2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "grism_detector")
-    d2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "grism_detector")
+    # Check that direct_frame -> grism is working before checking full transform
+    d2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("direct_frame", "grism_frame")
+    d2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("direct_frame", "grism_frame")
 
     d2g1_expected = (1084.130391789169, 2044.4123782198496, 1024.0, 2048.0, 1.0)
     d2g2_expected = (1080.3572828816784, 2045.548766180373, 1024.0, 2048.0, 1.0)
@@ -36,11 +36,11 @@ def test_acs_g800l_roundtrip():
     world_ref1 = (264.0677510637033, -32.91199329438908, 0.7*u.Unit("micron"), 1.0)
     world_ref2 = (264.1018298204877, -32.90801703429679, 0.7*u.Unit("micron"), 1.0)
 
-    g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_detector", "world")
-    w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
+    g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_frame", "world")
+    w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_frame")
 
-    g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_detector", "world")
-    w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_detector")
+    g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_frame", "world")
+    w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_frame")
 
     w2g1_expected = (2103.325418, 1020.241261, 2047.007260, 1022.979833, 1.0)
     w2g2_expected = (2099.471492, 1020.803474, 2047.001747, 1023.005213, 1.0)
@@ -57,15 +57,15 @@ def test_acs_g800l_roundtrip():
     [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
      range(len(world_ref2))]
 
-    # Test world <-> detector transforms
+    # Test world <-> direct_frame transforms
     w2d1_expected = (2047, 1023, 0.7*u.Unit("micron"), 1.0)
     w2d2_expected = (2047, 1023, 0.7*u.Unit("micron"), 1.0)
 
-    d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "world")
-    w2d1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "detector")
+    d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("direct_frame", "world")
+    w2d1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "direct_frame")
 
-    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "world")
-    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "detector")
+    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("direct_frame", "world")
+    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "direct_frame")
 
     [assert_quantity_allclose(w2d1(*world_ref1)[i], w2d1_expected[i], rtol=5e-5) for
      i in range(len(world_ref1))]

--- a/astrogrism/tests/test_image2grism.py
+++ b/astrogrism/tests/test_image2grism.py
@@ -21,7 +21,7 @@ testdata = [
 @pytest.mark.parametrize("grism,grism_image", testdata)
 def test_wfc3_grismconf(grism, grism_image):
     """
-    Tests the Astrogrism Detector > Grism Transform against
+    Tests the Astrogrism direct_frame > grism frame transform against
     grismconf's grism transform
     """
     # Download grismconf repo
@@ -81,8 +81,8 @@ def _image2grism(x_center, y_center, wavelengths, grism_file=None):
         raise NotImplementedError("Grism FLT File is required for now")
 
     grismobs = GrismObs(grism_file)
-    image2grism = grismobs.geometric_transforms.get_transform('detector',
-                                                              'grism_detector')
+    image2grism = grismobs.geometric_transforms.get_transform('direct_frame',
+                                                              'grism_frame')
     x, y = list(), list()
     for val in wavelengths:
         print(f"Val: {val}, x_cen: {x_center}, y_cen: {y_center}")
@@ -98,8 +98,8 @@ def _grism2image(x_center, y_center, x_dispersion, y_dispersion, grism_file=None
         raise NotImplementedError("Grism FLT File is required for now")
 
     grismobs = GrismObs(grism_file)
-    grism2image = grismobs.geometric_transforms.get_transform('grism_detector',
-                                                              'detector')
+    grism2image = grismobs.geometric_transforms.get_transform('grism_frame',
+                                                              'direct_frame')
     if len(x_dispersion) != len(y_dispersion):
         raise AttributeError("Non-equal quantities of coordinates provided")
 

--- a/astrogrism/tests/test_image2world.py
+++ b/astrogrism/tests/test_image2world.py
@@ -17,7 +17,7 @@ testdata = [
 @pytest.mark.parametrize('grism_image', testdata)
 def test_wfc3_astropywcs(grism_image):
     """
-    Tests the Astrogrism Detector > World Transform against
+    Tests the Astrogrism direct frame > world frame transform against
     the built in Astropy WCS model
     """
     # Define Pixel Grid
@@ -35,7 +35,7 @@ def test_wfc3_astropywcs(grism_image):
     # Init GrismObs
     grismobs = GrismObs(grism_image)
     # Retrieve Transform
-    image2world = grismobs.geometric_transforms.get_transform('detector',
+    image2world = grismobs.geometric_transforms.get_transform('direct_frame',
                                                               'world')
     # Calculate sky coordinates on grid
     astrogrism_ra, astrogrism_dec = image2world(xx, yy, 0, 0)[:2]
@@ -46,7 +46,7 @@ def test_wfc3_astropywcs(grism_image):
 
     # Check Roundtripping
     world2image = grismobs.geometric_transforms.get_transform('world',
-                                                              'detector')
+                                                              'direct_frame')
     xx_roundtrip, yy_roundtrip, _, _ = world2image(astrogrism_ra, astrogrism_dec, 0, 0)
     np.testing.assert_allclose(xx, xx_roundtrip, atol=5e-05)
     np.testing.assert_allclose(yy, yy_roundtrip, atol=5e-05)

--- a/astrogrism/tests/test_subarrays.py
+++ b/astrogrism/tests/test_subarrays.py
@@ -12,17 +12,17 @@ test_dir = pathlib.Path(__file__).parent.absolute()
 def test_uvis_subarray():
     """
     Tests Astrogrism transforms round tripping as expected between grism
-    detector, direct detector and world frames.
+    frame, direct frame and world frames.
     """
     test_file = pathlib.Path(test_dir, "data", "uvis_subarray_test_file.fits")
     grism_obs = GrismObs(str(test_file))
     grism_hdr = grism_obs.grism_image[1].header
 
-    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_detector',
-                                                                       'detector', 'world']
+    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_frame',
+                                                                       'direct_frame', 'world']
 
-    # Check that detector -> grism is working before checking full transform
-    d2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "grism_detector")
+    # Check that direct_frame -> grism is working before checking full transform
+    d2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("direct_frame", "grism_frame")
 
     d2g2_expected = (418.3477, 1673.770, 600.0, 1500.0, 1.0)
 
@@ -31,8 +31,8 @@ def test_uvis_subarray():
     # Now test transforming all the way end to end
     world_ref2 = (grism_hdr["CRVAL1"], grism_hdr["CRVAL2"], 4000*u.AA, 1.0)
 
-    g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_detector", "world")
-    w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_detector")
+    g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_frame", "world")
+    w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_frame")
 
     for key, value in grism_hdr.items():
         print(f"{key}: {value}")
@@ -45,11 +45,11 @@ def test_uvis_subarray():
     [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
      range(len(world_ref2))]
 
-    # Test world <-> detector transforms
+    # Test world <-> direct_frame transforms
     w2d_expected = (grism_hdr["CRPIX1"]-1, grism_hdr["CRPIX2"]-1, 4000*u.AA, 1.0)
 
-    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "world")
-    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "detector")
+    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("direct_frame", "world")
+    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "direct_frame")
 
     [assert_quantity_allclose(w2d2(*world_ref2)[i], w2d_expected[i], rtol=5e-5) for
      i in range(len(world_ref2))]
@@ -62,17 +62,17 @@ def test_uvis_subarray():
 def test_ir_subarray():
     """
     Tests Astrogrism transforms round tripping as expected between grism
-    detector, direct detector and world frames.
+    frame, direct frame and world frames.
     """
     test_file = pathlib.Path(test_dir, "data", "wfc3ir_subarray_test_file.fits")
     grism_obs = GrismObs(str(test_file))
     grism_hdr = grism_obs.grism_image[1].header
 
-    assert grism_obs.geometric_transforms.available_frames == ['grism_detector',
-                                                               'detector', 'world']
+    assert grism_obs.geometric_transforms.available_frames == ['grism_frame',
+                                                               'direct_frame', 'world']
 
-    # Check that detector -> grism is working before checking full transform
-    d2g = grism_obs.geometric_transforms.get_transform("detector", "grism_detector")
+    # Check that direct_frame -> grism is working before checking full transform
+    d2g = grism_obs.geometric_transforms.get_transform("direct_frame", "grism_frame")
 
     d2g_expected = (94.127118654, 137.60409411, 137.0, 137.0, 1.0)
 
@@ -81,8 +81,8 @@ def test_ir_subarray():
     # Now test transforming all the way end to end
     world_ref = (grism_hdr["CRVAL1"], grism_hdr["CRVAL2"], 7000*u.AA, 1.0)
 
-    g2w = grism_obs.geometric_transforms.get_transform("grism_detector", "world")
-    w2g = grism_obs.geometric_transforms.get_transform("world", "grism_detector")
+    g2w = grism_obs.geometric_transforms.get_transform("grism_frame", "world")
+    w2g = grism_obs.geometric_transforms.get_transform("world", "grism_frame")
 
     w2g_expected = (94.1271186539101, 137.60409410896412, grism_hdr["CRPIX1"]-1,
                     grism_hdr["CRPIX2"]-1, 1.0)
@@ -94,11 +94,11 @@ def test_ir_subarray():
     [assert_quantity_allclose(g2w_res[i], world_ref[i], rtol=0.005) for i in
      range(len(world_ref))]
 
-    # Test world <-> detector transforms
+    # Test world <-> direct_frame transforms
     w2d_expected = (grism_hdr["CRPIX1"]-1, grism_hdr["CRPIX2"]-1, 7000*u.AA, 1.0)
 
-    d2w = grism_obs.geometric_transforms.get_transform("detector", "world")
-    w2d = grism_obs.geometric_transforms.get_transform("world", "detector")
+    d2w = grism_obs.geometric_transforms.get_transform("direct_frame", "world")
+    w2d = grism_obs.geometric_transforms.get_transform("world", "direct_frame")
 
     [assert_quantity_allclose(w2d(*world_ref)[i], w2d_expected[i], rtol=5e-5) for
      i in range(len(world_ref))]

--- a/astrogrism/tests/test_wfc3_g280.py
+++ b/astrogrism/tests/test_wfc3_g280.py
@@ -12,19 +12,19 @@ test_dir = pathlib.Path(__file__).parent.absolute()
 def test_wfc3_g280_roundtrip():
     """
     Tests Astrogrism transforms round tripping as expected between grism
-    detector, direct detector and world frames.
+    frame, direct frame and world frames.
     """
     test_file = pathlib.Path(test_dir, "data", "uvis_test_file.fits")
     grism_obs = GrismObs(str(test_file))
 
-    assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_detector',
-                                                                       'detector', 'world']
-    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_detector',
-                                                                       'detector', 'world']
+    assert grism_obs.geometric_transforms["CCD1"].available_frames == ['grism_frame',
+                                                                       'direct_frame', 'world']
+    assert grism_obs.geometric_transforms["CCD2"].available_frames == ['grism_frame',
+                                                                       'direct_frame', 'world']
 
-    # Check that detector -> grism is working before checking full transform
-    d2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "grism_detector")
-    d2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "grism_detector")
+    # Check that direct_frame -> grism is working before checking full transform
+    d2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("direct_frame", "grism_frame")
+    d2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("direct_frame", "grism_frame")
 
     d2g1_expected = (1247.1169881075878, 1680.2088037732872, 1500.0, 1500.0, 1.0)
     d2g2_expected = (750.5270115330625, 1671.8505273099233, 1000.0, 1500.0, 1.0)
@@ -36,11 +36,11 @@ def test_wfc3_g280_roundtrip():
     world_ref1 = (206.45684221694, 26.41827449813, 4000*u.AA, 1.0)
     world_ref2 = (206.4312669986, 26.41859812035, 4000*u.AA, 1.0)
 
-    g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_detector", "world")
-    w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
+    g2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("grism_frame", "world")
+    w2g1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "grism_frame")
 
-    g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_detector", "world")
-    w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_detector")
+    g2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("grism_frame", "world")
+    w2g2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "grism_frame")
 
     w2g1_expected = (1869.5620631381307, 1199.8189959488238, 2046.9999576026378,
                      1025.000003223617, 1.0)
@@ -58,14 +58,14 @@ def test_wfc3_g280_roundtrip():
     [assert_quantity_allclose(g2w2_res[i], world_ref2[i], rtol=0.005) for i in
      range(len(world_ref2))]
 
-    # Test world <-> detector transforms
+    # Test world <-> direct_frame transforms
     w2d_expected = (2047, 1025, 4000*u.AA, 1.0)
 
-    d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("detector", "world")
-    w2d1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "detector")
+    d2w1 = grism_obs.geometric_transforms["CCD1"].get_transform("direct_frame", "world")
+    w2d1 = grism_obs.geometric_transforms["CCD1"].get_transform("world", "direct_frame")
 
-    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("detector", "world")
-    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "detector")
+    d2w2 = grism_obs.geometric_transforms["CCD2"].get_transform("direct_frame", "world")
+    w2d2 = grism_obs.geometric_transforms["CCD2"].get_transform("world", "direct_frame")
 
     [assert_quantity_allclose(w2d1(*world_ref1)[i], w2d_expected[i], rtol=5e-5) for
      i in range(len(world_ref1))]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,17 +16,17 @@ notebook cell, replacing the filename with your file::
     import astropy.units as u
     g_obs = GrismObs("sample_grism_flt.fits")
 
-This object makes available the tranforms between the ``world``, ``detector`` 
-(i.e. the undispersed direct image), and ``grism_detector`` frames. To get 
+This object makes available the tranforms between the ``world``, ``direct_frame`` 
+(i.e. the undispersed direct image), and ``grism_frame`` reference frames. To get 
 the transform between, for example, the world and grism detector frames, you 
 can call::
 
-    world_to_grism = g_obs.geometric_transforms.get_transform("world", "grism_detector")
+    world_to_grism = g_obs.geometric_transforms.get_transform("world", "grism_frame")
 
 For instruments with two chips (WFC3 UVIS and ACS), you must specify the chip for
 which you want the transform, e.g.::
 
-    world_to_grism = g_obs.geometric_transforms["CCD1"].get_transform("world", "grism_detector")
+    world_to_grism = g_obs.geometric_transforms["CCD1"].get_transform("world", "grism_frame")
 
 This transform would then allow you to calculate the coordinates on the dispersed image
 given a right ascension and declination (currently required to be in degrees), the

--- a/docs/transforms.rst
+++ b/docs/transforms.rst
@@ -61,7 +61,7 @@ example, the following would be valid uses::
     from astrogrism import GrismObs
     import astropy.units as u
     g_obs = GrismObs("sample_grism_flt.fits")
-    detector_to_grism = g_obs.geometric_transforms["CCD1"].get_transform("detector", "grism_detector")
+    detector_to_grism = g_obs.geometric_transforms["CCD1"].get_transform("direct_frame", "grism_frame")
 
     # Array inputs for spatial (pixel) coordinates
     detector_to_grism([1024, 1030, 1036], [2048.0, 2050, 2052], .7*u.um, 1.0)

--- a/notebooks/AstrogrismExample.ipynb
+++ b/notebooks/AstrogrismExample.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "direct_to_grism = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"detector\", \"grism_detector\")"
+    "direct_to_grism = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"direct_frame\", \"grism_frame\")"
    ]
   },
   {
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grism_to_direct = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"grism_detector\", \"detector\")\n",
+    "grism_to_direct = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"grism_frame\", \"direct_frame\")\n",
     "grism_to_direct.inputs"
    ]
   },
@@ -193,8 +193,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "world_to_direct = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"world\", \"detector\")\n",
-    "world_to_grism = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"world\", \"grism_detector\")"
+    "world_to_direct = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"world\", \"direct_frame\")\n",
+    "world_to_grism = grism_obs.geometric_transforms[\"CCD1\"].get_transform(\"world\", \"grism_frame\")"
    ]
   },
   {


### PR DESCRIPTION
Renames from "detector" and "grism_detector" to "direct_frame" and "grism_frame". I could see an argument for just "direct" and "grism" as well, since the world reference frame is just "world".